### PR TITLE
allow to pass charset in content-type

### DIFF
--- a/src/request/middleware/json-body.ts
+++ b/src/request/middleware/json-body.ts
@@ -16,7 +16,8 @@ export default function parseJsonBody(
 ): InterfaceRequest {
   const { headers, body } = request
 
-  return headers['content-type'].split(';').shift() === 'application/json' &&
+  return headers['content-type'] &&
+    headers['content-type'].split(';').shift() === 'application/json' &&
     typeof body === 'string'
     ? { ...request, body: parseJson(body) }
     : request

--- a/src/request/middleware/json-body.ts
+++ b/src/request/middleware/json-body.ts
@@ -16,7 +16,7 @@ export default function parseJsonBody(
 ): InterfaceRequest {
   const { headers, body } = request
 
-  return headers['content-type'] === 'application/json' &&
+  return headers['content-type'].split(';').shift() === 'application/json' &&
     typeof body === 'string'
     ? { ...request, body: parseJson(body) }
     : request

--- a/src/request/middleware/url-encoded-body.ts
+++ b/src/request/middleware/url-encoded-body.ts
@@ -9,8 +9,8 @@ export default function parseUrlEncodedBody(
 ): InterfaceRequest {
   const { headers, body } = request
 
-  return headers['content-type'].split(';').shift() === 'application/x-www-form-urlencoded' &&
-    typeof body === 'string'
+  return headers['content-type'].split(';').shift() ===
+    'application/x-www-form-urlencoded' && typeof body === 'string'
     ? { ...request, body: querystring.parse(body) }
     : request
 }

--- a/src/request/middleware/url-encoded-body.ts
+++ b/src/request/middleware/url-encoded-body.ts
@@ -9,8 +9,10 @@ export default function parseUrlEncodedBody(
 ): InterfaceRequest {
   const { headers, body } = request
 
-  return headers['content-type'].split(';').shift() ===
-    'application/x-www-form-urlencoded' && typeof body === 'string'
+  return headers['content-type'] &&
+    headers['content-type'].split(';').shift() ===
+      'application/x-www-form-urlencoded' &&
+    typeof body === 'string'
     ? { ...request, body: querystring.parse(body) }
     : request
 }

--- a/src/request/middleware/url-encoded-body.ts
+++ b/src/request/middleware/url-encoded-body.ts
@@ -9,7 +9,7 @@ export default function parseUrlEncodedBody(
 ): InterfaceRequest {
   const { headers, body } = request
 
-  return headers['content-type'] === 'application/x-www-form-urlencoded' &&
+  return headers['content-type'].split(';').shift() === 'application/x-www-form-urlencoded' &&
     typeof body === 'string'
     ? { ...request, body: querystring.parse(body) }
     : request


### PR DESCRIPTION
some users might pass a spec compliant thing like `content-type: application/x-www-form-urlencoded; charset=utf-8`