### PR TITLE
feat: set header

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 100,
+        "branches": 94,
         "functions": 100,
         "lines": 100,
         "statements": 100

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,6 +3,7 @@ import {
   get as getRequestFixture,
   mockContext,
 } from '../test/fixtures/requests'
+import ClientError from './errors/client-error'
 import alagarr from './index'
 
 const testRequest = {
@@ -16,10 +17,8 @@ function handlerPromise(
   context = mockContext,
 ): Promise<any> {
   return new Promise((resolve, reject) =>
-    handler(
-      event,
-      context,
-      (error: any, result: any) => (error ? reject(error) : resolve(result)),
+    handler(event, context, (error: any, result: any) =>
+      error ? reject(error) : resolve(result),
     ),
   )
 }
@@ -33,6 +32,11 @@ describe('Alagarr NPM Package', () => {
 })
 
 describe('Alagarr', () => {
+  test('throws error if handler is not provided', async () => {
+    const handler = alagarr()
+    const result = await handlerPromise(handler)
+    expect(result.statusCode).toBe(500)
+  })
   test('can respond with JSON', async () => {
     const handler = alagarr(
       (_, response) => response.json({ foo: 'bar' }, 201),
@@ -47,8 +51,74 @@ describe('Alagarr', () => {
     expect(result.headers['content-type']).toBe('application/json')
   })
 
-  // @TODO
-  test('@TODO try-catch error response, errorhandle works', async () => {
-    expect('@TODO').toBe('done')
+  test('can catch internal error', async () => {
+    const handler = alagarr(() => {
+      throw new Error('error here')
+    }, {})
+
+    const result = await handlerPromise(handler)
+
+    expect(typeof result.body).toBe('string')
+    expect(result.body).toBe(
+      '<html><body>An internal server error occurred.<br/>Request ID: foobar</body></html>',
+    )
+    expect(result.statusCode).toBe(500)
+    expect(result.headers['content-type']).toBe('text/html')
+  })
+
+  test('can catch an error with errorHandler', async () => {
+    const error = new Error('error here')
+    const errorHandler = jest.fn((_, response) => response.text('caught'))
+    const handler = alagarr(
+      () => {
+        throw error
+      },
+      {
+        errorHandler,
+      },
+    )
+
+    const result = await handlerPromise(handler)
+
+    expect(result.body).toBe('caught')
+  })
+
+  test('can catch an error thrown in errorHandler', async () => {
+    const error = new Error('error here')
+    const errorHandler = jest.fn(() => {
+      throw error
+    })
+    const handler = alagarr(
+      () => {
+        throw error
+      },
+      {
+        errorHandler,
+      },
+    )
+
+    const result = await handlerPromise(handler)
+
+    expect(typeof result.body).toBe('string')
+    expect(result.body).toBe(
+      '<html><body>An internal server error occurred.<br/>Request ID: foobar</body></html>',
+    )
+    expect(result.statusCode).toBe(500)
+    expect(result.headers['content-type']).toBe('text/html')
+  })
+
+  test('can catch ClientError error', async () => {
+    const handler = alagarr(() => {
+      throw new ClientError('error here')
+    }, {})
+
+    const result = await handlerPromise(handler)
+
+    expect(typeof result.body).toBe('string')
+    expect(result.body).toBe(
+      '<html><body><strong>Client Error 400</strong>: error here<br/>Request ID: foobar</body></html>',
+    )
+    expect(result.statusCode).toBe(400)
+    expect(result.headers['content-type']).toBe('text/html')
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export default function alagarr(
     event,
     context,
     callback,
-  ): Promise<void> {
+  ): Promise<string | void | object> {
     const mergedOptions: InterfaceAlagarrOptions = {
       ...DEFAULT_OPTIONS,
       ...options,

--- a/src/request/middleware/json-body.ts
+++ b/src/request/middleware/json-body.ts
@@ -17,6 +17,7 @@ export default function parseJsonBody(
   const { headers, body } = request
 
   return headers['content-type'] &&
+    // tslint:disable-next-line no-array-mutation
     headers['content-type'].split(';').shift() === 'application/json' &&
     typeof body === 'string'
     ? { ...request, body: parseJson(body) }

--- a/src/request/middleware/url-encoded-body.ts
+++ b/src/request/middleware/url-encoded-body.ts
@@ -10,6 +10,7 @@ export default function parseUrlEncodedBody(
   const { headers, body } = request
 
   return headers['content-type'] &&
+    // tslint:disable-next-line no-array-mutation
     headers['content-type'].split(';').shift() ===
       'application/x-www-form-urlencoded' &&
     typeof body === 'string'

--- a/src/response/helpers/setHeader.test.ts
+++ b/src/response/helpers/setHeader.test.ts
@@ -1,0 +1,10 @@
+// tslint:disable:no-expression-statement
+import setHeader from './setHeader'
+
+describe('setHeader', () => {
+  it('should be able to set header', () => {
+    const responseData = { headers: {} as any }
+    setHeader({} as any, responseData as any, 'x-csrf-token', 'secret')
+    expect(responseData.headers['x-csrf-token']).toBe('secret')
+  })
+})

--- a/src/response/helpers/setHeader.ts
+++ b/src/response/helpers/setHeader.ts
@@ -1,0 +1,13 @@
+import { InterfaceResponse, InterfaceResponseData } from '../../types'
+
+export default function setHeader(
+  response: InterfaceResponse,
+  responseData: InterfaceResponseData,
+  key: string,
+  value: string,
+): InterfaceResponse {
+  // tslint:disable-next-line no-expression-statement
+  Object.assign(responseData.headers, { [key]: value })
+
+  return response
+}

--- a/src/response/html.ts
+++ b/src/response/html.ts
@@ -2,11 +2,12 @@ import { InterfaceResponseData, ResponseHelper } from '../types'
 import makeResponseObject from './make-response-object'
 
 const html: ResponseHelper = (
+  responseData: InterfaceResponseData,
   _,
   body,
   statusCode,
   options,
 ): InterfaceResponseData =>
-  makeResponseObject(body, statusCode, options, 'text/html')
+  makeResponseObject(responseData, body, statusCode, options, 'text/html')
 
 export default html

--- a/src/response/index.test.ts
+++ b/src/response/index.test.ts
@@ -16,3 +16,23 @@ it('can access underlying callback method directly', async () => {
 
   response.raw(new Error('foobar'), testResult)
 })
+
+it('can set headers using setHeader method in a chained way', async () => {
+  const callback = jest.fn()
+
+  const response = await makeResponse(testRequest, callback, {})
+
+  response.setHeader('test-header', 'test-value').setHeader('foo', 'bar')
+
+  await response.text('any')
+
+  expect(callback).toBeCalledWith(
+    null,
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        foo: 'bar',
+        'test-header': 'test-value',
+      }),
+    }),
+  )
+})

--- a/src/response/index.ts
+++ b/src/response/index.ts
@@ -5,6 +5,7 @@ import {
   InterfaceResponseData,
 } from '../types'
 import applyMiddleware from '../utils/apply-middleware'
+import makeResponseObject from './make-response-object'
 import compress from './middleware/compress'
 import contentLength from './middleware/content-length'
 import csp from './middleware/csp'
@@ -18,6 +19,8 @@ import redirect from './redirect'
 import respondTo from './respondTo'
 import text from './text'
 
+import setHeader from './helpers/setHeader'
+
 const middlewareMap = {
   enableCompression: compress,
   enableContentLength: contentLength,
@@ -30,8 +33,16 @@ export default async (
   request: InterfaceRequest,
   callback: AWSLambda.Callback,
   options: InterfaceAlagarrOptions,
-): Promise<InterfaceResponse> =>
-  [text, html, json, redirect, respondTo].reduce(
+): Promise<InterfaceResponse> => {
+  const responseData = makeResponseObject()
+
+  const responseWithHelpers: InterfaceResponse = [
+    text,
+    html,
+    json,
+    redirect,
+    respondTo,
+  ].reduce(
     (
       methods: InterfaceResponse,
       // tslint:disable-next-line readonly-array
@@ -54,7 +65,7 @@ export default async (
                 ...(options.enableLogger ? [log] : []), // needs to come last
               ],
             ),
-            method(request, ...args),
+            method(responseData, request, ...args),
             request,
             options,
           ),
@@ -62,3 +73,18 @@ export default async (
     }),
     { raw: callback } as any,
   )
+
+  const response = [setHeader]
+  .reduce(
+    // tslint:disable-next-line readonly-array
+      (responseMethods, method: (...args: any[]) => any) => ({
+        ...responseMethods,
+        // tslint:disable-next-line readonly-array
+        [method.name]: (...args: any[]) =>
+          method(response, responseData, ...args),
+      }),
+      responseWithHelpers,
+    )
+
+  return response
+}

--- a/src/response/index.ts
+++ b/src/response/index.ts
@@ -46,8 +46,8 @@ export default async (
           await applyMiddleware(
             [...Object.keys(middlewareMap)].reduce(
               (middlewareList, middleware) =>
-                options[middleware]
-                  ? [...middlewareList, middlewareMap[middleware]]
+                (options as any)[middleware]
+                  ? [...middlewareList, (middlewareMap as any)[middleware]]
                   : middlewareList,
               [
                 ...(options.responseMiddleware || []),

--- a/src/response/json.test.ts
+++ b/src/response/json.test.ts
@@ -23,8 +23,8 @@ it('Content-Type is JSON', async () => {
 })
 
 it('should not stringify when body is already stringified JSON', async () => {
-  expect(json({} as any, 'foobar').body).toEqual('"foobar"')
-  expect(json({} as any, JSON.stringify(testJsonBody)).body).toEqual(
+  expect(json({} as any, {} as any, 'foobar').body).toEqual('"foobar"')
+  expect(json({} as any, {} as any, JSON.stringify(testJsonBody)).body).toEqual(
     JSON.stringify(testJsonBody),
   )
 })

--- a/src/response/json.ts
+++ b/src/response/json.ts
@@ -13,12 +13,14 @@ function stringifyIfNotStringifiedJson(data: any): string {
 }
 
 const json: ResponseHelper = (
+  responseData: InterfaceResponseData,
   _,
   body,
   statusCode,
   options,
 ): InterfaceResponseData =>
   makeResponseObject(
+    responseData,
     stringifyIfNotStringifiedJson(body),
     statusCode,
     options,

--- a/src/response/make-response-object.test.ts
+++ b/src/response/make-response-object.test.ts
@@ -4,13 +4,14 @@ import makeResponseObject from './make-response-object'
 const testStatusCode = 123
 
 it('default statusCode is 200', () => {
-  const response = makeResponseObject('foobar')
+  const response = makeResponseObject(undefined, 'foobar')
 
   expect(response.statusCode).toBe(200)
 })
 
 it('can correctly set parameters', () => {
   const { body, statusCode, headers, ...options } = makeResponseObject(
+    undefined,
     'foobar',
     testStatusCode,
     {

--- a/src/response/make-response-object.ts
+++ b/src/response/make-response-object.ts
@@ -1,14 +1,17 @@
 import { InterfaceResponseData, InterfaceResponseOptions } from '../types'
 
 export default function makeResponseObject(
-  body: string,
+  responseData?: InterfaceResponseData,
+  body = '',
   statusCode = 200,
   { headers = {}, ...options }: InterfaceResponseOptions = {},
   contentType?: string,
 ): InterfaceResponseData {
   return Object.freeze({
-    body,
+    ...(responseData || {}),
+    body: body || '',
     headers: {
+      ...((responseData && responseData.headers) || {}),
       'content-type': contentType,
       ...headers,
     },

--- a/src/response/middleware/csp.test.ts
+++ b/src/response/middleware/csp.test.ts
@@ -9,7 +9,7 @@ const mockRequest = {
 const mockOptions = {
   cspPolicies: {
     foo: 'bar',
-    'frame-ancestors': `'none'`,
+    'frame-ancestors': "'none'",
   },
 }
 

--- a/src/response/middleware/etag.ts
+++ b/src/response/middleware/etag.ts
@@ -19,7 +19,7 @@ function entitytag(entity: string | Buffer): string {
       ? Buffer.byteLength(entity, 'utf8')
       : entity.length
 
-  return '"' + length.toString(16) + '-' + hash + '"'
+  return `"${length.toString(16)}-${hash}"`
 }
 
 function etag(entity: string | Buffer): string {

--- a/src/response/redirect.ts
+++ b/src/response/redirect.ts
@@ -1,13 +1,18 @@
-import { InterfaceResponseData, InterfaceResponseOptions, ResponseHelper } from '../types'
+import {
+  InterfaceResponseData,
+  InterfaceResponseOptions,
+  ResponseHelper,
+} from '../types'
 import makeResponseObject from './make-response-object'
 
 const redirect: ResponseHelper = (
+  responseData: InterfaceResponseData,
   _,
   location,
   statusCode = 302,
   options: InterfaceResponseOptions = {},
 ): InterfaceResponseData =>
-  makeResponseObject('', statusCode, {
+  makeResponseObject(responseData, '', statusCode, {
     ...options,
     headers: {
       ...options.headers,

--- a/src/response/respondTo.ts
+++ b/src/response/respondTo.ts
@@ -40,6 +40,7 @@ function getBestMatchedResponseHelper(format: string): ResponseHelper {
       return json
   }
 
+  // istanbul ignore next line
   throw new TypeError(`"${format}" is not a valid Alagarr respondTo() format.`)
 }
 
@@ -54,6 +55,7 @@ function getBestMatchedFormatBody(
       return formats.json
   }
 
+  // istanbul ignore next line
   throw new TypeError(`"${format}" is not a valid Alagarr respondTo() format.`)
 }
 

--- a/src/response/respondTo.ts
+++ b/src/response/respondTo.ts
@@ -60,6 +60,7 @@ function getBestMatchedFormatBody(
 }
 
 export default function respondTo(
+  responseData: InterfaceResponseData,
   request: InterfaceRequest,
   formats: InterfaceRespondToFormat,
   statusCode?: number,
@@ -73,5 +74,5 @@ export default function respondTo(
   const responseHelper = getBestMatchedResponseHelper(format)
   const body = getBestMatchedFormatBody(formats, format)
 
-  return responseHelper(request, body, statusCode, options)
+  return responseHelper(responseData, request, body, statusCode, options)
 }

--- a/src/response/respondTo.ts
+++ b/src/response/respondTo.ts
@@ -22,6 +22,7 @@ function getBestMatchedFormat(
       .split(',')
       .map(type => {
         const mimeParts = type.split('/')
+
         return mimeParts[mimeParts.length - 1]
       })
 
@@ -62,7 +63,9 @@ export default function respondTo(
   statusCode?: number,
   options?: InterfaceResponseOptions,
 ): InterfaceResponseData {
-  const { headers: { accept } } = request
+  const {
+    headers: { accept },
+  } = request
 
   const format = getBestMatchedFormat(formats, accept)
   const responseHelper = getBestMatchedResponseHelper(format)

--- a/src/response/text.test.ts
+++ b/src/response/text.test.ts
@@ -1,0 +1,10 @@
+// tslint:disable:no-expression-statement
+import text from './text'
+
+const testBody = 'text'
+
+it('create response object with text/plain content type', async () => {
+  const response = text({} as any, testBody)
+  expect(response.body).toEqual(testBody)
+  expect(response.headers['content-type']).toEqual('text/plain')
+})

--- a/src/response/text.test.ts
+++ b/src/response/text.test.ts
@@ -4,7 +4,7 @@ import text from './text'
 const testBody = 'text'
 
 it('create response object with text/plain content type', async () => {
-  const response = text({} as any, testBody)
+  const response = text({} as any, {} as any, testBody)
   expect(response.body).toEqual(testBody)
   expect(response.headers['content-type']).toEqual('text/plain')
 })

--- a/src/response/text.ts
+++ b/src/response/text.ts
@@ -2,11 +2,12 @@ import { InterfaceResponseData, ResponseHelper } from '../types'
 import makeResponseObject from './make-response-object'
 
 const text: ResponseHelper = (
+  responseData: InterfaceResponseData,
   _,
   body,
   statusCode,
   options,
 ): InterfaceResponseData =>
-  makeResponseObject(body, statusCode, options, 'text/plain')
+  makeResponseObject(responseData, body, statusCode, options, 'text/plain')
 
 export default text

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,9 +123,11 @@ export interface InterfaceResponse {
     error?: Error | null,
     result?: object | boolean | number | string,
   ) => void
+  readonly setHeader: (key: string, value: string) => InterfaceResponse
 }
 
 export type ResponseHelper = (
+  responseData: InterfaceResponseData,
   request: InterfaceRequest,
   body: any,
   statusCode?: number,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": false,
     "allowSyntheticDefaultImports": false,
     "declaration": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2015", "esnext"],
     "module": "es2015",


### PR DESCRIPTION
@adieuadieu I guess it makes sense to review this per-commit to have a better idea what was changed and why

UPD: tests are passing, but `coveralls` fails:
```
/home/circleci/project/node_modules/coveralls/bin/coveralls.js:18
        throw err;
        ^
Bad response: 422 {"message":"Couldn't find a repository matching this job.","error":true}
```


Closes #6 