### PR TITLE
fix(readme): fix custom middleware example

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,8 +605,8 @@ const handler = require('alagarr')
 const { restoreSession, saveSession } = require('./custom-middleware')
 
 const alagarrConfig = {
-  requestMiddleware: ['default', restoreSession],
-  responseMiddleware: ['default', saveSession],
+  requestMiddleware: [restoreSession],
+  responseMiddleware: [saveSession],
 }
 
 module.exports.userDashboardHandler = handler((request, response) => {


### PR DESCRIPTION
fix(readme): fix custom middleware example

Otherwise
```
TypeError: middleware is not a function

      at Object.<anonymous> (node_modules/alagarr/dist/src/utils/apply-middleware.js:13:117)
      at fulfilled (node_modules/alagarr/dist/src/utils/apply-middleware.js:4:58)
```