### PR TITLE
Fix example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,8 +605,8 @@ const handler = require('alagarr')
 const { restoreSession, saveSession } = require('./custom-middleware')
 
 const alagarrConfig = {
-  requestMiddleware: ['default', restoreSession],
-  responseMiddleware: ['default', saveSession],
+  requestMiddleware: [restoreSession],
+  responseMiddleware: [saveSession],
 }
 
 module.exports.userDashboardHandler = handler((request, response) => {


### PR DESCRIPTION
This example did not work for me. I copied this with the expectation that `['default']` enables the default middlewares. However this seems not be true. It failed with `middleware is not a function`.

